### PR TITLE
Account for the fact that some stubs may be entirely excluded from the pyright check

### DIFF
--- a/src/typeshed_stats/gather.py
+++ b/src/typeshed_stats/gather.py
@@ -43,7 +43,7 @@ __all__ = [
     "gather_stats_on_package",
     "get_package_size",
     "get_package_status",
-    "get_pyright_strictness",
+    "get_pyright_setting",
     "get_stubtest_setting",
 ]
 

--- a/src/typeshed_stats/gather.py
+++ b/src/typeshed_stats/gather.py
@@ -8,13 +8,13 @@ import re
 import sys
 import urllib.parse
 from collections import Counter
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from contextlib import AsyncExitStack, contextmanager
 from enum import Enum
 from functools import cache
 from operator import attrgetter
 from pathlib import Path
-from typing import Any, Protocol, TypeAlias, TypeVar, final
+from typing import Any, Literal, Protocol, TypeAlias, TypeVar, final
 
 import aiohttp
 import attrs
@@ -415,10 +415,14 @@ def get_package_size(package_name: str, *, typeshed_dir: Path | str) -> int:
 
 
 @cache
-def _get_pyright_strict_excludelist(typeshed_dir: Path | str) -> frozenset[Path]:
-    # Read pyrightconfig.stricter.json;
+def _get_pyright_excludelist(
+    *,
+    typeshed_dir: Path | str,
+    config_filename: Literal["pyrightconfig.json", "pyrightconfig.stricter.json"],
+) -> frozenset[Path]:
+    # Read the config file;
     # do some pre-processing so that it can be passed to json.loads()
-    config_path = Path(typeshed_dir, "pyrightconfig.stricter.json")
+    config_path = Path(typeshed_dir, config_filename)
     with config_path.open(encoding="utf-8") as file:
         # strip comments from the file
         lines = [line for line in file if not line.strip().startswith("//")]
@@ -433,15 +437,27 @@ def _get_pyright_strict_excludelist(typeshed_dir: Path | str) -> frozenset[Path]
 class PyrightSetting(_NiceReprEnum):
     """The various possible pyright settings typeshed uses in CI."""
 
-    STRICT = "All files are tested with the stricter pyright settings in CI."
+    ENTIRELY_EXCLUDED = "All files are excluded from the pyright check in CI."
+    SOME_FILES_EXCLUDED = "Some files are excluded from the pyright check in CI."
     NOT_STRICT = "All files are excluded from the stricter pyright settings in CI."
     STRICT_ON_SOME_FILES = (
         "Some files are tested with the stricter pyright settings in CI;"
         " some are excluded."
     )
+    STRICT = "All files are tested with the stricter pyright settings in CI."
 
 
-def get_pyright_strictness(
+def _path_or_path_ancestor_is_listed(path: Path, path_list: Collection[Path]) -> bool:
+    return path in path_list or any(
+        listed_path in path.parents for listed_path in path_list
+    )
+
+
+def _child_of_path_is_listed(path: Path, path_list: Collection[Path]) -> bool:
+    return any(path in listed_path.parents for listed_path in path_list)
+
+
+def get_pyright_setting(
     package_name: PackageName, *, typeshed_dir: Path | str
 ) -> PyrightSetting:
     """Get the setting typeshed uses in CI when pyright is run on a certain package.
@@ -456,16 +472,22 @@ def get_pyright_strictness(
         (see the docs on `PyrightSetting` for details).
     """
     package_directory = _get_package_directory(package_name, typeshed_dir)
-    excluded_paths = _get_pyright_strict_excludelist(typeshed_dir)
-    if package_directory in excluded_paths:
-        return PyrightSetting.NOT_STRICT
-    if any(
-        excluded_path in package_directory.parents for excluded_path in excluded_paths
+    entirely_excluded_paths = _get_pyright_excludelist(
+        typeshed_dir=typeshed_dir, config_filename="pyrightconfig.json"
+    )
+    paths_excluded_from_stricter_check = _get_pyright_excludelist(
+        typeshed_dir=typeshed_dir, config_filename="pyrightconfig.stricter.json"
+    )
+
+    if _path_or_path_ancestor_is_listed(package_directory, entirely_excluded_paths):
+        return PyrightSetting.ENTIRELY_EXCLUDED
+    if _child_of_path_is_listed(package_directory, entirely_excluded_paths):
+        return PyrightSetting.SOME_FILES_EXCLUDED
+    if _path_or_path_ancestor_is_listed(
+        package_directory, paths_excluded_from_stricter_check
     ):
         return PyrightSetting.NOT_STRICT
-    if any(
-        package_directory in excluded_path.parents for excluded_path in excluded_paths
-    ):
+    if _child_of_path_is_listed(package_directory, paths_excluded_from_stricter_check):
         return PyrightSetting.STRICT_ON_SOME_FILES
     return PyrightSetting.STRICT
 
@@ -514,7 +536,7 @@ async def gather_stats_on_package(
             package_name, typeshed_dir=typeshed_dir, session=session
         ),
         stubtest_setting=get_stubtest_setting(package_name, typeshed_dir=typeshed_dir),
-        pyright_setting=get_pyright_strictness(package_name, typeshed_dir=typeshed_dir),
+        pyright_setting=get_pyright_setting(package_name, typeshed_dir=typeshed_dir),
         annotation_stats=gather_annotation_stats_on_package(
             package_name, typeshed_dir=typeshed_dir
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,7 @@ def complete_typeshed(
     for directory in "stdlib", "stubs":
         (typeshed / directory).mkdir()
 
+    (typeshed / "pyrightconfig.json").write_text("{}", encoding="utf-8")
     pyrightconfig_path = typeshed / "pyrightconfig.stricter.json"
     pyrightconfig_path.write_text(pyrightconfig_template.format(""), encoding="utf-8")
 

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -221,7 +221,7 @@ class TestPassingPackages:
         patches_to_apply = [
             ("get_package_status", PackageStatus.UP_TO_DATE),
             ("get_stubtest_setting", StubtestSetting.MISSING_STUBS_IGNORED),
-            ("get_pyright_strictness", PyrightSetting.STRICT_ON_SOME_FILES),
+            ("get_pyright_setting", PyrightSetting.STRICT_ON_SOME_FILES),
         ]
 
         for function_name, return_value in patches_to_apply:

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -417,32 +417,89 @@ def test_get_package_size_multiple_files(
 
 
 @pytest.mark.parametrize(
-    ("excluded_path", "package_to_test", "pyright_setting_name"),
+    (
+        "entirely_excluded_path",
+        "path_excluded_from_strict",
+        "package_to_test",
+        "pyright_setting_name",
+    ),
     [
-        pytest.param("stdlib", "stdlib", "NOT_STRICT", id="case1"),
-        pytest.param("stdlib/tkinter", "stdlib", "STRICT_ON_SOME_FILES", id="case2"),
-        pytest.param("stubs", "stdlib", "STRICT", id="case3"),
-        pytest.param("stubs/aiofiles", "stdlib", "STRICT", id="case4"),
-        pytest.param("stubs", "appdirs", "NOT_STRICT", id="case5"),
-        pytest.param("stubs", "boto", "NOT_STRICT", id="case6"),
-        pytest.param("stubs/boto", "appdirs", "STRICT", id="case7"),
-        pytest.param("stubs/boto/auth.pyi", "boto", "STRICT_ON_SOME_FILES", id="case8"),
+        # Some files are entirely excluded, none are excluded from strict settings
+        pytest.param("stdlib", None, "stdlib", "ENTIRELY_EXCLUDED", id="case1"),
+        pytest.param(
+            "stdlib/tkinter", None, "stdlib", "SOME_FILES_EXCLUDED", id="case2"
+        ),
+        pytest.param("stdlib", None, "boto", "STRICT", id="case3"),
+        pytest.param("stubs", None, "aiofiles", "ENTIRELY_EXCLUDED", id="case4"),
+        pytest.param(
+            "stubs/aiofiles", None, "aiofiles", "ENTIRELY_EXCLUDED", id="case5"
+        ),
+        pytest.param("stubs/aiofiles", None, "boto", "STRICT", id="case6"),
+        # No files are entirely excluded, some are excluded from strict settings
+        pytest.param(None, "stdlib", "stdlib", "NOT_STRICT", id="case7"),
+        pytest.param(
+            None, "stdlib/tkinter", "stdlib", "STRICT_ON_SOME_FILES", id="case8"
+        ),
+        pytest.param(None, "stubs", "stdlib", "STRICT", id="case9"),
+        pytest.param(None, "stubs/aiofiles", "stdlib", "STRICT", id="case10"),
+        pytest.param(None, "stubs", "appdirs", "NOT_STRICT", id="case11"),
+        pytest.param(None, "stubs", "boto", "NOT_STRICT", id="case12"),
+        pytest.param(None, "stubs/boto", "appdirs", "STRICT", id="case13"),
+        pytest.param(
+            None, "stubs/boto/auth.pyi", "boto", "STRICT_ON_SOME_FILES", id="case14"
+        ),
+        # Some files are entirely excluded, some are excluded from strict settings
+        pytest.param(
+            "stdlib", "stdlib/tkinter", "stdlib", "ENTIRELY_EXCLUDED", id="case15"
+        ),
+        pytest.param(
+            "stdlib/tkinter",
+            "stdlib/asyncio",
+            "stdlib",
+            "SOME_FILES_EXCLUDED",
+            id="case16",
+        ),
+        pytest.param(
+            "stubs", "stdlib/tkinter", "stdlib", "STRICT_ON_SOME_FILES", id="case17"
+        ),
+        pytest.param("stubs", "stubs/boto", "boto", "ENTIRELY_EXCLUDED", id="case18"),
+        pytest.param(
+            "stubs/boto/auth.pyi",
+            "stubs/boto/foo.pyi",
+            "boto",
+            "SOME_FILES_EXCLUDED",
+            id="case19",
+        ),
     ],
 )
 def test_get_pyright_setting(
     typeshed: Path,
-    excluded_path: str,
+    entirely_excluded_path: str | None,
+    path_excluded_from_strict: str | None,
     package_to_test: str,
     pyright_setting_name: str,
     maybe_stringize_path: Callable[[Path], Path | str],
     pyrightconfig_template: str,
 ) -> None:
-    pyrightconfig = pyrightconfig_template.format(f'"{excluded_path}"')
-    with pytest.raises(json.JSONDecodeError):
-        json.loads(pyrightconfig)
-    (typeshed / "pyrightconfig.json").write_text("{}", encoding="utf-8")
-    strict_pyright_config_path = typeshed / "pyrightconfig.stricter.json"
-    strict_pyright_config_path.write_text(pyrightconfig, encoding="utf-8")
+    foo_path = "foo.pyi"
+    pyright_basicconfig = pyrightconfig_template.format(
+        f'"{entirely_excluded_path or foo_path}"'
+    )
+    pyright_strictconfig = pyrightconfig_template.format(
+        f'"{path_excluded_from_strict or foo_path}"'
+    )
+
+    config_filenames_to_configs = {
+        "pyrightconfig.json": pyright_basicconfig,
+        "pyrightconfig.stricter.json": pyright_strictconfig,
+    }
+
+    for config_filename, config in config_filenames_to_configs.items():
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(config)
+
+        (typeshed / config_filename).write_text(config, encoding="utf-8")
+
     pyright_setting = get_pyright_setting(
         package_name=package_to_test, typeshed_dir=maybe_stringize_path(typeshed)
     )

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -31,7 +31,7 @@ from typeshed_stats.gather import (
     gather_stats,
     get_package_size,
     get_package_status,
-    get_pyright_strictness,
+    get_pyright_setting,
     get_stubtest_setting,
     tmpdir_typeshed,
 )
@@ -412,7 +412,7 @@ def test_get_package_size_multiple_files(
 
 
 # ================================
-# Tests for get_pyright_strictness
+# Tests for get_pyright_setting
 # ================================
 
 
@@ -440,13 +440,14 @@ def test_get_pyright_setting(
     pyrightconfig = pyrightconfig_template.format(f'"{excluded_path}"')
     with pytest.raises(json.JSONDecodeError):
         json.loads(pyrightconfig)
-    pyrightconfig_path = typeshed / "pyrightconfig.stricter.json"
-    pyrightconfig_path.write_text(pyrightconfig, encoding="utf-8")
-    pyright_strictness = get_pyright_strictness(
+    (typeshed / "pyrightconfig.json").write_text("{}", encoding="utf-8")
+    strict_pyright_config_path = typeshed / "pyrightconfig.stricter.json"
+    strict_pyright_config_path.write_text(pyrightconfig, encoding="utf-8")
+    pyright_setting = get_pyright_setting(
         package_name=package_to_test, typeshed_dir=maybe_stringize_path(typeshed)
     )
     expected_result = PyrightSetting[pyright_setting_name]
-    assert pyright_strictness is expected_result
+    assert pyright_setting is expected_result
 
 
 # =========================


### PR DESCRIPTION
- Add new logic accounting for the fact that some stubs may be entirely skipped by pyright
- Add tests
