### PR TITLE
Fix mypy failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "attrs>=21.3.0",
+    "attrs>=22.2.0",
     "cattrs",
     "aiohttp[speedups]",
     "packaging",

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -1,5 +1,5 @@
 aiohttp
-attrs
+attrs>=22.2.0
 cattrs
 mypy==0.991
 packaging

--- a/scripts/regenerate.py
+++ b/scripts/regenerate.py
@@ -126,7 +126,7 @@ def regenerate_gather_api_docs() -> None:
                 )
             elif attrs.has(thing):
                 rows = []
-                for field in attrs.fields(thing):  # type: ignore[arg-type]
+                for field in attrs.fields(thing):
                     typ_description = _get_field_description(field)
                     rows.append([f"`{field.name}`", typ_description])
                 docs += "**Attributes:**\n\n"


### PR DESCRIPTION
A `type: ignore` comment was no longer necessary, due to the release of `attrs` 22.2.0.

Fixes #49