### PR TITLE
Generate stats on allowlist lengths

### DIFF
--- a/src/typeshed_stats/gather.py
+++ b/src/typeshed_stats/gather.py
@@ -512,10 +512,10 @@ def get_stubtest_allowlist_length(
         The number of allowlist entries for that package.
 
     Examples:
-        >>> from typeshed_stats.gather import tmpdir_typeshed, get_allowlist_length
+        >>> from typeshed_stats.gather import tmpdir_typeshed, get_stubtest_allowlist_length
         >>> with tmpdir_typeshed() as typeshed:
-        ...     num_stdlib_allows = get_allowlist_length("stdlib", typeshed_dir=typeshed)
-        ...     num_requests_allows = get_allowlist_length("requests", typeshed_dir=typeshed)
+        ...     num_stdlib_allows = get_stubtest_allowlist_length("stdlib", typeshed_dir=typeshed)
+        ...     num_requests_allows = get_stubtest_allowlist_length("requests", typeshed_dir=typeshed)
         >>> type(num_stdlib_allows)
         <class 'int'>
         >>> num_stdlib_allows > 0 and num_requests_allows > 0

--- a/src/typeshed_stats/serialize.py
+++ b/src/typeshed_stats/serialize.py
@@ -154,7 +154,6 @@ def _stats_from_csv(
         converted_stat["annotation_stats"] = annotation_stats
         converted_stat["stubtest_settings"] = stubtest_settings
         if cls is PackageInfo:
-            stubtest_settings = converted_stat["stubtest_settings"]
             stubtest_platforms = stubtest_settings["platforms"]
             if stubtest_platforms == "None":
                 stubtest_settings["platforms"] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,8 @@ from typeshed_stats.gather import (
     PackageInfo,
     PackageStatus,
     PyrightSetting,
-    StubtestSetting,
+    StubtestSettings,
+    StubtestStrictness,
     UploadStatus,
 )
 
@@ -220,8 +221,8 @@ def random_AnnotationStats() -> AnnotationStats:
 
 def random_PackageInfo() -> PackageInfo:
     package_name = random_identifier()
-    stubtest_setting = random.choice(list(StubtestSetting))
-    if stubtest_setting is StubtestSetting.SKIPPED:
+    stubtest_strictness = random.choice(list(StubtestStrictness))
+    if stubtest_strictness is StubtestStrictness.SKIPPED:
         stubtest_platforms = []
     else:
         stubtest_platforms = [random.choice(["win32", "darwin", "linux"])]
@@ -231,8 +232,7 @@ def random_PackageInfo() -> PackageInfo:
         extra_description=None,
         number_of_lines=random.randint(10, 500),
         package_status=random.choice(list(PackageStatus)),
-        stubtest_setting=stubtest_setting,
-        stubtest_platforms=stubtest_platforms,
+        stubtest_settings=StubtestSettings(stubtest_strictness, stubtest_platforms),
         upload_status=random.choice(list(UploadStatus)),
         pyright_setting=random.choice(list(PyrightSetting)),
         annotation_stats=random_AnnotationStats(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,7 +232,7 @@ def random_PackageInfo() -> PackageInfo:
         extra_description=None,
         number_of_lines=random.randint(10, 500),
         package_status=random.choice(list(PackageStatus)),
-        stubtest_settings=StubtestSettings(stubtest_strictness, stubtest_platforms),
+        stubtest_settings=StubtestSettings(stubtest_strictness, stubtest_platforms, 55),
         upload_status=random.choice(list(UploadStatus)),
         pyright_setting=random.choice(list(PyrightSetting)),
         annotation_stats=random_AnnotationStats(),

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -24,7 +24,7 @@ from typeshed_stats.gather import (
     PackageInfo,
     PackageStatus,
     PyrightSetting,
-    StubtestSetting,
+    StubtestStrictness,
     UploadStatus,
 )
 
@@ -223,7 +223,7 @@ class TestPassingPackages:
     ) -> None:
         patches_to_apply = [
             ("get_package_status", PackageStatus.UP_TO_DATE),
-            ("get_stubtest_setting", StubtestSetting.MISSING_STUBS_IGNORED),
+            ("get_stubtest_strictness", StubtestStrictness.MISSING_STUBS_IGNORED),
             ("get_pyright_setting_for_package", PyrightSetting.STRICT_ON_SOME_FILES),
             ("get_package_extra_description", None),
             ("get_upload_status", UploadStatus.UPLOADED),

--- a/tests/test__cli.py
+++ b/tests/test__cli.py
@@ -229,6 +229,7 @@ class TestPassingPackages:
             ("get_upload_status", UploadStatus.UPLOADED),
             ("get_stubtest_platforms", ["linux"]),
             ("get_stub_distribution_name", "types-foo"),
+            ("get_stubtest_allowlist_length", 55),
         ]
 
         for function_name, return_value in patches_to_apply:

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -27,7 +27,7 @@ from typeshed_stats.gather import (
     PackageInfo,
     PackageStatus,
     PyrightSetting,
-    StubtestSetting,
+    StubtestStrictness,
     UploadStatus,
     _get_pypi_data,
     gather_annotation_stats_on_file,
@@ -40,7 +40,7 @@ from typeshed_stats.gather import (
     get_pyright_setting_for_package,
     get_stub_distribution_name,
     get_stubtest_platforms,
-    get_stubtest_setting,
+    get_stubtest_strictness,
     get_upload_status,
     tmpdir_typeshed,
 )
@@ -53,10 +53,10 @@ from .conftest import PYRIGHTCONFIG_TEMPLATE, write_metadata_text
 
 
 def test__NiceReprEnum_docstring_equals_enum_value() -> None:
-    assert StubtestSetting.SKIPPED.__doc__ == StubtestSetting.SKIPPED.value
+    assert StubtestStrictness.SKIPPED.__doc__ == StubtestStrictness.SKIPPED.value
 
 
-@pytest.mark.parametrize("obj", [StubtestSetting, StubtestSetting.SKIPPED])
+@pytest.mark.parametrize("obj", [StubtestStrictness, StubtestStrictness.SKIPPED])
 def test__NiceReprEnum_docstring_in_help_output(
     obj: object, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -66,18 +66,18 @@ def test__NiceReprEnum_docstring_in_help_output(
 
 
 def test__NiceReprEnum_repr_str() -> None:
-    assert repr(StubtestSetting.SKIPPED) == "StubtestSetting.SKIPPED"
-    assert str(StubtestSetting.SKIPPED) == repr(StubtestSetting.SKIPPED)
-    assert StubtestSetting.SKIPPED.value not in repr(StubtestSetting.SKIPPED)
+    assert repr(StubtestStrictness.SKIPPED) == "StubtestStrictness.SKIPPED"
+    assert str(StubtestStrictness.SKIPPED) == repr(StubtestStrictness.SKIPPED)
+    assert StubtestStrictness.SKIPPED.value not in repr(StubtestStrictness.SKIPPED)
 
 
 @pytest.mark.parametrize(
     ("enum_member", "expected_formatted_name"),
     [
         pytest.param(
-            StubtestSetting.ERROR_ON_MISSING_STUB,
+            StubtestStrictness.ERROR_ON_MISSING_STUB,
             "error on missing stub",
-            id="StubtestSetting",
+            id="StubtestStrictness",
         ),
         pytest.param(
             PackageStatus.NO_LONGER_UPDATED, "no longer updated", id="PackageStatus"
@@ -227,21 +227,21 @@ def test_get_package_extra_description_with_description(
 
 
 # ==============================
-# Tests for get_stubtest_setting
+# Tests for get_stubtest_strictness
 # ==============================
 
 
-def test_get_stubtest_setting_stdlib(typeshed: Path) -> None:
-    result = get_stubtest_setting("stdlib", typeshed_dir=typeshed)
-    assert result is StubtestSetting.ERROR_ON_MISSING_STUB
+def test_get_stubtest_strictness_stdlib(typeshed: Path) -> None:
+    result = get_stubtest_strictness("stdlib", typeshed_dir=typeshed)
+    assert result is StubtestStrictness.ERROR_ON_MISSING_STUB
 
 
-def test_get_stubtest_setting_non_stdlib_no_stubtest_section(
+def test_get_stubtest_strictness_non_stdlib_no_stubtest_section(
     EXAMPLE_PACKAGE_NAME: str, typeshed: Path
 ) -> None:
     write_metadata_text(typeshed, EXAMPLE_PACKAGE_NAME, "\n")
-    result = get_stubtest_setting(EXAMPLE_PACKAGE_NAME, typeshed_dir=typeshed)
-    assert result is StubtestSetting.MISSING_STUBS_IGNORED
+    result = get_stubtest_strictness(EXAMPLE_PACKAGE_NAME, typeshed_dir=typeshed)
+    assert result is StubtestStrictness.MISSING_STUBS_IGNORED
 
 
 @pytest.mark.parametrize(
@@ -270,7 +270,7 @@ def test_get_stubtest_setting_non_stdlib_no_stubtest_section(
         ),
     ],
 )
-def test_get_stubtest_setting_non_stdlib_with_stubtest_section(
+def test_get_stubtest_strictness_non_stdlib_with_stubtest_section(
     EXAMPLE_PACKAGE_NAME: str,
     typeshed: Path,
     metadata_contents: str,
@@ -280,10 +280,10 @@ def test_get_stubtest_setting_non_stdlib_with_stubtest_section(
     write_metadata_text(
         typeshed, EXAMPLE_PACKAGE_NAME, f"[tool.stubtest]\n{metadata_contents}"
     )
-    actual_result = get_stubtest_setting(
+    actual_result = get_stubtest_strictness(
         EXAMPLE_PACKAGE_NAME, typeshed_dir=maybe_stringize_path(typeshed)
     )
-    expected_result = StubtestSetting[expected_result_name]
+    expected_result = StubtestStrictness[expected_result_name]
     assert actual_result is expected_result
 
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -67,7 +67,7 @@ def unusual_packages() -> list[PackageInfo]:
         package_status=PackageStatus.UP_TO_DATE,
         upload_status=UploadStatus.NOT_CURRENTLY_UPLOADED,
         stubtest_settings=StubtestSettings(
-            strictness=StubtestStrictness.SKIPPED, platforms=[]
+            strictness=StubtestStrictness.SKIPPED, platforms=[], allowlist_length=0
         ),
         pyright_setting=PyrightSetting.STRICT,
         annotation_stats=AnnotationStats(),

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -73,6 +73,7 @@ def unusual_packages() -> list[PackageInfo]:
         annotation_stats=AnnotationStats(),
     )
     pkg2 = copy.deepcopy(pkg1)
+    pkg2.package_name = "stdlib"
     pkg2.stubtest_settings.strictness = StubtestStrictness.ERROR_ON_MISSING_STUB
     pkg2.stubtest_settings.platforms = ["win32", "darwin"]
     pkg2.stub_distribution_name = "-"
@@ -133,6 +134,9 @@ def test_markdown_and_htmlconversion(
     converted_to_markdown = stats_to_markdown(list_of_info)
     assert converted_to_markdown[-1] == "\n"
     assert converted_to_markdown[-2] != "\n"
+    assert "`stdlib`" not in converted_to_markdown
+    assert "`the stdlib`" not in converted_to_markdown
+    assert "``" not in converted_to_markdown
     html1 = markdown.markdown(converted_to_markdown)
     soup = BeautifulSoup(html1, "html.parser")
     assert bool(soup.find()), "Invalid HTML produced!"

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -14,7 +14,8 @@ from typeshed_stats.gather import (
     PackageInfo,
     PackageStatus,
     PyrightSetting,
-    StubtestSetting,
+    StubtestSettings,
+    StubtestStrictness,
     UploadStatus,
 )
 from typeshed_stats.serialize import (
@@ -65,17 +66,18 @@ def unusual_packages() -> list[PackageInfo]:
         number_of_lines=100_000_000_000,
         package_status=PackageStatus.UP_TO_DATE,
         upload_status=UploadStatus.NOT_CURRENTLY_UPLOADED,
-        stubtest_setting=StubtestSetting.SKIPPED,
-        stubtest_platforms=[],
+        stubtest_settings=StubtestSettings(
+            strictness=StubtestStrictness.SKIPPED, platforms=[]
+        ),
         pyright_setting=PyrightSetting.STRICT,
         annotation_stats=AnnotationStats(),
     )
     pkg2 = copy.deepcopy(pkg1)
-    pkg2.stubtest_setting = StubtestSetting.ERROR_ON_MISSING_STUB
-    pkg2.stubtest_platforms = ["win32", "darwin"]
+    pkg2.stubtest_settings.strictness = StubtestStrictness.ERROR_ON_MISSING_STUB
+    pkg2.stubtest_settings.platforms = ["win32", "darwin"]
     pkg2.stub_distribution_name = "-"
     pkg3 = copy.deepcopy(pkg2)
-    pkg3.stubtest_platforms = ["win32", "darwin", "linux"]
+    pkg3.stubtest_settings.platforms = ["win32", "darwin", "linux"]
     return [pkg1, pkg2, pkg3]
 
 


### PR DESCRIPTION
- Refactor how stubtest settings are obtained
- Gather stats on allowlist lengths
- Show allowlist lengths in generated markdown
