### PR TITLE
Fix generated MarkDown links

### DIFF
--- a/src/typeshed_stats/serialize.py
+++ b/src/typeshed_stats/serialize.py
@@ -239,4 +239,11 @@ def stats_to_markdown(stats: Sequence[PackageInfo]) -> str:
         return template.render(**kwargs)
 
     all_packages = "\n\n<hr>\n\n".join(format_package(info) for info in stats)
+    all_packages += (
+        "\n\n"
+        "[stubtest]: "
+        "https://mypy.readthedocs.io/en/stable/stubtest.html "
+        '"A tool shipped with the mypy type checker for automatically verifying '
+        'that stubs are consistent with the runtime package"'
+    )
     return re.sub(r"\n{3,}", "\n\n", all_packages).strip() + "\n"


### PR DESCRIPTION
Using the `.snippets` extension works great for the website, but doesn't work so well for the MarkDown-generation function in `serialize.py`, which I guess I'd prefer to keep independent of the website. Not sure if that's really worth it or viable long-term, but we'll see.