### PR TITLE
Improve `renovate` config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,17 +15,22 @@
         "github-actions"
       ],
       "description": "Group all GitHub Action dependencies",
-      "separateMajorMinor": "false"
+      "separateMajorMinor": "false",
+      "stabilityDays": 7
     },
     {
       "groupName": "pip-dependencies",
       "matchManagers": [
         "pip_requirements"
       ],
-      "description": "Group all pip requirements"
+      "description": "Group all pip requirements",
+      "stabilityDays": 7
     }
   ],
   "schedule": [
     "after 6pm"
+  ],
+  "suppressNotifications": [
+    "prEditedNotification"
   ]
 }


### PR DESCRIPTION
- Don't create a PR for a dependency if the new release is <7 days old (it might get yanked).
- Don't complain passive-aggressively at me if I edit the PR it makes.