### PR TITLE
Pin some requirements more tightly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           pip install -e .[rich]
           pip install -r requirements/all.txt
+          pip freeze --all
       - name: Run mypy on the project
         run: mypy
 

--- a/.github/workflows/regen-examples-and-docs.yml
+++ b/.github/workflows/regen-examples-and-docs.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           pip install -r requirements/docs.txt
           pip install -e .[rich]
+          pip freeze --all
       - name: Regenerate examples and docs
         id: regen
         run: python scripts/regenerate.py --download-typeshed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           pip install -r requirements/pytest.txt coveralls
           pip install -e .[rich]
+          pip freeze --all
       - name: Run tests under coverage
         run: |
           coverage run -m pytest --doctest-modules

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
-mkdocs>=1.4,<2
+mkdocs==1.4.2
 mkdocs-macros-plugin==0.7.0
-mkdocs-material>=9,<10
-mkdocs-table-reader-plugin>=1,<2
+mkdocs-material==9.0.1
+mkdocs-table-reader-plugin==1.2
 mkdocstrings[python]==0.19.1

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -1,10 +1,11 @@
+# Don't pin anything too tightly if it's also a dependency of the library...
 aiohttp
 attrs>=22.2.0
 cattrs
 Jinja2>=3
 mypy==0.991
 packaging
-pytest>=7,<8
+pytest==7.2.0
 pytest-mock==3.10.0
 rich
 rich-argparse>=0.6.0

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,8 +1,8 @@
 beautifulsoup4>=4,<5
 covdefaults==2.2.2
-coverage>=6,<8
+coverage==7.0.2
 Markdown>=3,<4
-pytest>=7,<8
+pytest==7.2.0
 pytest-antilru==1.1.1
 pytest-asyncio==0.20.3
 pytest-dependency==0.5.1

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,6 +1,6 @@
 beautifulsoup4>=4,<5
 covdefaults==2.2.2
-coverage==7.0.2
+coverage==6.5.0
 Markdown>=3,<4
 pytest==7.2.0
 pytest-antilru==1.1.1


### PR DESCRIPTION
These requirements are either needed for the website or testing, so there's no real reason not to pin them more tightly, and it helps with reproducibility.