### PR TITLE
Fix logic for getting stubtest strictness following recent typeshed change

### DIFF
--- a/src/typeshed_stats/gather.py
+++ b/src/typeshed_stats/gather.py
@@ -438,10 +438,10 @@ def get_stubtest_strictness(
     match _get_stubtest_config(package_name, typeshed_dir):
         case {"skip": True}:
             return StubtestStrictness.SKIPPED
-        case {"ignore_missing_stub": False}:
-            return StubtestStrictness.ERROR_ON_MISSING_STUB
-        case _:
+        case {"ignore_missing_stub": True}:
             return StubtestStrictness.MISSING_STUBS_IGNORED
+        case _:
+            return StubtestStrictness.ERROR_ON_MISSING_STUB
 
 
 def get_stubtest_platforms(

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -243,14 +243,14 @@ def test_get_stubtest_strictness_non_stdlib_no_stubtest_section(
 ) -> None:
     write_metadata_text(typeshed, EXAMPLE_PACKAGE_NAME, "\n")
     result = get_stubtest_strictness(EXAMPLE_PACKAGE_NAME, typeshed_dir=typeshed)
-    assert result is StubtestStrictness.MISSING_STUBS_IGNORED
+    assert result is StubtestStrictness.ERROR_ON_MISSING_STUB
 
 
 @pytest.mark.parametrize(
     ("metadata_contents", "expected_result_name"),
     [
-        pytest.param("", "MISSING_STUBS_IGNORED", id="empty_metadata"),
-        pytest.param("skip = false", "MISSING_STUBS_IGNORED", id="skip=False"),
+        pytest.param("", "ERROR_ON_MISSING_STUB", id="empty_metadata"),
+        pytest.param("skip = false", "ERROR_ON_MISSING_STUB", id="skip=False"),
         pytest.param(
             "ignore_missing_stub = true",
             "MISSING_STUBS_IGNORED",


### PR DESCRIPTION
The default was changed in https://github.com/python/typeshed/commit/ed6748fb32207a9b831a8c50000c40cb87892a45