### PR TITLE
Improve logic for determining whether files have been excluded from pyright's checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "cattrs",
     "aiohttp[speedups]",
     "packaging",
+    "pathspec>=0.10.3",
     "Jinja2>=3",
     "tomli; python_version < '3.11'",
 ]

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -5,6 +5,7 @@ cattrs
 Jinja2>=3
 mypy==1.1.1
 packaging
+pathspec>=0.10.3  # needs to be py.typed
 pytest==7.2.2
 pytest-mock==3.10.0
 rich

--- a/src/typeshed_stats/gather.py
+++ b/src/typeshed_stats/gather.py
@@ -19,6 +19,7 @@ from typing import (
     Annotated,
     Any,
     Literal,
+    NamedTuple,
     NewType,
     TypeAlias,
     TypeGuard,
@@ -30,6 +31,8 @@ import aiohttp
 import attrs
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+from pathspec import PathSpec
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
 if sys.version_info < (3, 10):
     raise ImportError("Python 3.10+ is required!")
@@ -823,12 +826,24 @@ def _is_str_list(obj: object) -> TypeGuard[list[str]]:
     return isinstance(obj, list) and all(isinstance(item, str) for item in obj)
 
 
+class _ExcludeList(NamedTuple):
+    spec: PathSpec
+    pathlist: list[Path]
+
+
+def _normalized_path(path: Path) -> str:
+    normalized_path = path.as_posix()
+    if path.is_dir():
+        normalized_path += "/"
+    return normalized_path
+
+
 @lru_cache
 def _get_pyright_excludelist(
     *,
     typeshed_dir: Path | str,
     config_filename: Literal["pyrightconfig.json", "pyrightconfig.stricter.json"],
-) -> frozenset[Path]:
+) -> _ExcludeList:
     # Read the config file;
     # do some pre-processing so that it can be passed to json.loads()
     config_path = Path(typeshed_dir, config_filename)
@@ -841,7 +856,14 @@ def _get_pyright_excludelist(
     assert isinstance(pyright_config, dict)
     excludelist: object = pyright_config.get("exclude", [])
     assert _is_str_list(excludelist)
-    return frozenset(Path(typeshed_dir, item) for item in excludelist)
+    excludelist_as_paths = [Path(typeshed_dir, item) for item in excludelist]
+    return _ExcludeList(
+        PathSpec.from_lines(
+            GitWildMatchPattern,
+            [_normalized_path(item) for item in excludelist_as_paths],
+        ),
+        excludelist_as_paths,
+    )
 
 
 class PyrightSetting(_NiceReprEnum):
@@ -871,10 +893,8 @@ class PyrightSetting(_NiceReprEnum):
     )
 
 
-def _path_or_path_ancestor_is_listed(path: Path, path_list: Collection[Path]) -> bool:
-    return path in path_list or any(
-        listed_path in path.parents for listed_path in path_list
-    )
+def _path_or_path_ancestor_is_listed(path: Path, excludelist: _ExcludeList) -> bool:
+    return excludelist.spec.match_file(_normalized_path(path))
 
 
 def _child_of_path_is_listed(path: Path, path_list: Collection[Path]) -> bool:
@@ -905,11 +925,11 @@ def get_pyright_setting_for_path(
 
     if _path_or_path_ancestor_is_listed(file_path, entirely_excluded_paths):
         return PyrightSetting.ENTIRELY_EXCLUDED
-    if _child_of_path_is_listed(file_path, entirely_excluded_paths):
+    if _child_of_path_is_listed(file_path, entirely_excluded_paths.pathlist):
         return PyrightSetting.SOME_FILES_EXCLUDED
     if _path_or_path_ancestor_is_listed(file_path, paths_excluded_from_stricter_check):
         return PyrightSetting.NOT_STRICT
-    if _child_of_path_is_listed(file_path, paths_excluded_from_stricter_check):
+    if _child_of_path_is_listed(file_path, paths_excluded_from_stricter_check.pathlist):
         return PyrightSetting.STRICT_ON_SOME_FILES
     return PyrightSetting.STRICT
 

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -708,7 +708,17 @@ PYRIGHT_TEST_CASES: Final = (
         expected_result="ENTIRELY_EXCLUDED",
     ),
     PyrightTestCase(
+        entirely_excluded_path="stdlib/**/*.pyi",
+        package_to_test="stdlib",
+        expected_result="ENTIRELY_EXCLUDED",
+    ),
+    PyrightTestCase(
         entirely_excluded_path="stdlib/tkinter",
+        package_to_test="stdlib",
+        expected_result="SOME_FILES_EXCLUDED",
+    ),
+    PyrightTestCase(
+        entirely_excluded_path="stdlib/lib2to3/fixes/*.pyi",
         package_to_test="stdlib",
         expected_result="SOME_FILES_EXCLUDED",
     ),
@@ -729,6 +739,11 @@ PYRIGHT_TEST_CASES: Final = (
         expected_result="ENTIRELY_EXCLUDED",
     ),
     PyrightTestCase(
+        entirely_excluded_path="stubs/aiofiles/**/*.pyi",
+        package_to_test="aiofiles",
+        expected_result="ENTIRELY_EXCLUDED",
+    ),
+    PyrightTestCase(
         entirely_excluded_path="stubs/aiofiles",
         path_excluded_from_strict=None,
         package_to_test="boto",
@@ -741,7 +756,17 @@ PYRIGHT_TEST_CASES: Final = (
         expected_result="NOT_STRICT",
     ),
     PyrightTestCase(
+        path_excluded_from_strict="stdlib/**/*.pyi",
+        package_to_test="stdlib",
+        expected_result="NOT_STRICT",
+    ),
+    PyrightTestCase(
         path_excluded_from_strict="stdlib/tkinter",
+        package_to_test="stdlib",
+        expected_result="STRICT_ON_SOME_FILES",
+    ),
+    PyrightTestCase(
+        path_excluded_from_strict="stdlib/tkinter/*.pyi",
         package_to_test="stdlib",
         expected_result="STRICT_ON_SOME_FILES",
     ),
@@ -752,6 +777,11 @@ PYRIGHT_TEST_CASES: Final = (
     ),
     PyrightTestCase(
         path_excluded_from_strict="stubs/aiofiles",
+        package_to_test="stdlib",
+        expected_result="STRICT",
+    ),
+    PyrightTestCase(
+        path_excluded_from_strict="stubs/aiofiles/*.pyi",
         package_to_test="stdlib",
         expected_result="STRICT",
     ),
@@ -779,6 +809,12 @@ PYRIGHT_TEST_CASES: Final = (
         expected_result="SOME_FILES_EXCLUDED",
     ),
     PyrightTestCase(
+        entirely_excluded_path="stdlib/tkinter/*.pyi",
+        path_excluded_from_strict="stdlib/asyncio/*.pyi",
+        package_to_test="stdlib",
+        expected_result="SOME_FILES_EXCLUDED",
+    ),
+    PyrightTestCase(
         entirely_excluded_path="stubs",
         path_excluded_from_strict="stdlib/tkinter",
         package_to_test="stdlib",
@@ -786,6 +822,12 @@ PYRIGHT_TEST_CASES: Final = (
     ),
     PyrightTestCase(
         entirely_excluded_path="stdlib",
+        path_excluded_from_strict="stubs/boto/auth.pyi",
+        package_to_test="boto",
+        expected_result="STRICT_ON_SOME_FILES",
+    ),
+    PyrightTestCase(
+        entirely_excluded_path="stdlib/*.pyi",
         path_excluded_from_strict="stubs/boto/auth.pyi",
         package_to_test="boto",
         expected_result="STRICT_ON_SOME_FILES",
@@ -1020,6 +1062,14 @@ def test_gather_stats__on_packages_integrates_with_tmpdir_typeshed() -> None:
     assert set(package_names_in_results) == package_names
 
 
+KNOWN_FULLY_ANNOTATED_FILES_WITH_LAX_PYRIGHT_SETTINGS = frozenset(
+    {
+        Path("stdlib/lib2to3/fixes/fix_imports2.pyi"),
+        Path("stdlib/lib2to3/fixes/__init__.pyi"),
+    }
+)
+
+
 @pytest.mark.dependency(depends=["integration_basic"])
 def test_basic_sanity_checks(subtests: SubTests) -> None:
     with tmpdir_typeshed() as typeshed:
@@ -1062,7 +1112,9 @@ def test_basic_sanity_checks(subtests: SubTests) -> None:
                     f"{f.file_path!r} has unannotated parameters and/or returns, "
                     "but has the strictest pyright settings in CI"
                 )
-            else:
+            elif (
+                f.file_path not in KNOWN_FULLY_ANNOTATED_FILES_WITH_LAX_PYRIGHT_SETTINGS
+            ):
                 assert is_only_partially_annotated, (
                     "Likely bug detected: "
                     f"{f.file_path!r} is fully annotated, "

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -722,7 +722,6 @@ PYRIGHT_TEST_CASES: Final = (
     ),
     PyrightTestCase(
         entirely_excluded_path="stdlib",
-        path_excluded_from_strict=None,
         package_to_test="boto",
         expected_result="STRICT",
     ),
@@ -743,7 +742,6 @@ PYRIGHT_TEST_CASES: Final = (
     ),
     PyrightTestCase(
         entirely_excluded_path="stubs/aiofiles",
-        path_excluded_from_strict=None,
         package_to_test="boto",
         expected_result="STRICT",
     ),


### PR DESCRIPTION
Add `pathspec` as a dependency. Fixes #118.