### PR TITLE
Remove `pycln` as a test dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,8 @@ repos:
       - id: check-case-conflict
       - id: name-tests-test
         args: [--pytest-test-first]
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.5 # must match pyproject.toml
-    hooks:
-      - id: pycln
-        args: [--config=pyproject.toml, .]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.278 # must match pyproject.toml
+    rev: v0.0.280 # must match pyproject.toml
     hooks:
       - id: ruff
   - repo: https://github.com/psf/black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,17 +86,12 @@ misc-lint = [
     "black==23.7.0",
     "blacken-docs==1.15.0",
     "pre-commit-hooks==4.4.0",
-    "pycln==2.1.5",
-    "ruff==0.0.278",
+    "ruff==0.0.280",
 ]
 dev = ["typeshed-stats[rich,docs,typecheck,pytest,misc-lint]"]
 
 [tool.hatch.version]
 path = "src/typeshed_stats/__init__.py"
-
-[tool.pycln]
-all = true
-disable_all_dunder_policy = true
 
 [tool.black]
 line_length = 88
@@ -118,6 +113,12 @@ ignore = [
     "PGH004",
     # I know when to and when not to use `eval()`
     "PGH001",
+]
+unfixable = [
+    "F841",  # unused variable. ruff keeps the call, but mostly we want to get rid of it all
+    "F601",  # automatic fix might obscure issue
+    "F602",  # automatic fix might obscure issue
+    "B018",  # automatic fix might obscure issue
 ]
 per-file-ignores = {"tests/*.py" = ["D"]}
 

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -56,9 +56,6 @@ def run_checks(
     download_typeshed: bool = False,
 ) -> None:
     """Run the checks."""
-    print("\nRunning pycln...")
-    subprocess.run(["pycln", ".", "--config=pyproject.toml"])
-
     print("\nRunning ruff...")
     subprocess.run(["ruff", "."])
 


### PR DESCRIPTION
`ruff` is just as good at removing unused imports.

Also, bump the ruff version, and improve the ruff config slightly.