### PR TITLE
Use `uv` activation script instead of routing environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,8 @@ jobs:
         run: |
           uv venv .venv
           echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+          echo "$PWD/.venv/Scripts" >> $GITHUB_PATH
       - name: Install dependencies
         run: uv pip install -e ".[pytest]"
       - run: uv pip freeze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,18 +50,37 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v5
         with:
           cache: "pip"
-          cache-dependency-path: "pyproject.toml"
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - run: pip install "wheel<1"
-      - run: pip install -e .[pytest]
-      - run: pip freeze --all
+      - name: Trick uv into thinking we've activated a venv
+        run: echo "VIRTUAL_ENV=${Python_ROOT_DIR}" >> $GITHUB_ENV
+      - name: Install uv
+        # Installing uv via curl is much faster than via pip,
+        # but there doesn't seem to be a great alternative to pip on Windows
+        # in the context of GitHub Actions
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            pip install "uv>=0.1.4"
+          else
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+          fi
+      - name: Uninstall pip
+        # we need to uninstall pip or uv complains about how setup-python
+        # has pip installed twice for some reason??
+        run: python -m pip uninstall pip --yes
+      - name: Install dependencies
+        run: uv pip install -e ".[pytest]"
+      - run: uv pip freeze
       - name: Run tests under coverage
         run: |
           coverage run -m pytest --doctest-modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,27 +62,27 @@ jobs:
           cache: "pip"
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - name: Install dependencies and run tests
+      - name: Install uv
         # Installing uv via curl is much faster than via pip,
         # but there doesn't seem to be a great alternative to pip on Windows
         # in the context of GitHub Actions
-        #
-        # Unfortunately uv doesn't allow you to install packages globally,
-        # and if you activate a venv, it is deactivated again
-        # as soon as the step ends,
-        # so we have to do the whole thing in one massive step here:
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
             pip install "uv>=0.1.4"
-            uv venv
-            .venv\Scripts\activate.bat
           else
             curl -LsSf https://astral.sh/uv/install.sh | sh
-            uv venv
-            source .venv/bin/activate
           fi
-          uv pip install -e ".[pytest]"
-          uv pip freeze
+        # uv doesn't allow us to install packages globally;
+        # we have to create a venv and install things into that
+      - name: Create and activate a virtual environment
+        run: |
+          uv venv .venv
+          echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: uv pip install -e ".[pytest]"
+      - run: uv pip freeze
+      - name: Run tests under coverage
+        run: |
           coverage run -m pytest --doctest-modules
           coverage report --no-skip-covered
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,27 +62,27 @@ jobs:
           cache: "pip"
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - name: Trick uv into thinking we've activated a venv
-        run: echo "VIRTUAL_ENV=${Python_ROOT_DIR}" >> $GITHUB_ENV
-      - name: Install uv
+      - name: Install dependencies and run tests
         # Installing uv via curl is much faster than via pip,
         # but there doesn't seem to be a great alternative to pip on Windows
         # in the context of GitHub Actions
+        #
+        # Unfortunately uv doesn't allow you to install packages globally,
+        # and if you activate a venv, it is deactivated again
+        # as soon as the step ends,
+        # so we have to do the whole thing in one massive step here:
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
             pip install "uv>=0.1.4"
+            uv venv
+            .venv\Scripts\activate.bat
           else
             curl -LsSf https://astral.sh/uv/install.sh | sh
+            uv venv
+            source .venv/bin/activate
           fi
-      - name: Uninstall pip
-        # we need to uninstall pip or uv complains about how setup-python
-        # has pip installed twice for some reason??
-        run: python -m pip uninstall pip --yes
-      - name: Install dependencies
-        run: uv pip install -e ".[pytest]"
-      - run: uv pip freeze
-      - name: Run tests under coverage
-        run: |
+          uv pip install -e ".[pytest]"
+          uv pip freeze
           coverage run -m pytest --doctest-modules
           coverage report --no-skip-covered
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,14 +77,12 @@ jobs:
       - name: Create and activate a virtual environment
         run: |
           uv venv .venv
-          echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
-          echo "$PWD/.venv/bin" >> $GITHUB_PATH
-          echo "$PWD/.venv/Scripts" >> $GITHUB_PATH
       - name: Install dependencies
         run: uv pip install -e ".[pytest]"
       - run: uv pip freeze
       - name: Run tests under coverage
         run: |
+          source ./.venv/Scripts/activate
           coverage run -m pytest --doctest-modules
           coverage report --no-skip-covered
 


### PR DESCRIPTION
- use `uv` in CI for the `test.yml` workflow
- Try using `uv` in the `tests.yml` workflow without the trick
- try this
- .
- Use activation script instead of environment variable
