### PR TITLE
Fix doctests

### DIFF
--- a/src/typeshed_stats/gather.py
+++ b/src/typeshed_stats/gather.py
@@ -448,7 +448,7 @@ def get_stubtest_strictness(
         >>> from typeshed_stats.gather import tmpdir_typeshed, get_stubtest_strictness
         >>> with tmpdir_typeshed() as typeshed:
         ...     stdlib_setting = get_stubtest_strictness("stdlib", typeshed_dir=typeshed)
-        ...     gdb_setting = get_stubtest_strictness("gdb", typeshed_dir=typeshed)
+        ...     gdb_setting = get_stubtest_strictness("RPi.GPIO", typeshed_dir=typeshed)
         >>> stdlib_setting
         StubtestStrictness.ERROR_ON_MISSING_STUB
         >>> help(_)


### PR DESCRIPTION
Fixes #211
Fixes #212 
Fixes #213
Fixes #214 
Fixes #215

This is just because gdb now has stubtest run on it in typeshed's CI (which I didn't think would ever happen!), and this doctest is couopled to typeshed in a silly way.