### PR TITLE
Remove accidentally committed uv binary

### DIFF
--- a/.github/workflows/regen-examples-and-docs.yml
+++ b/.github/workflows/regen-examples-and-docs.yml
@@ -47,7 +47,7 @@ jobs:
             && steps.lint.outcome == 'success'
           }}
         run: |
-          git add .
+          git add examples
           git diff --staged --quiet || git commit -m "👷 Automated regeneration of examples and docs"
           git push
       - name: Deploy docs


### PR DESCRIPTION
Fixes #277.

Not a huge fan of having to couple the GitHub workflow and the `regenerate.py` script together like this, but apparently `git add .` is too error-prone in the context of a GitHub workflow...