### PR TITLE
make CI output more colourful

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_COLOR: 1 # Request colored output from CLI tools supporting it
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/regen-examples-and-docs.yml
+++ b/.github/workflows/regen-examples-and-docs.yml
@@ -14,6 +14,9 @@ on:
       - "**.html"
   workflow_dispatch:
 
+env:
+  FORCE_COLOR: 1 # Request colored output from CLI tools supporting it
+
 jobs:
   regen_examples_and_docs:
     runs-on: ubuntu-latest
@@ -23,12 +26,17 @@ jobs:
         run: |
           git config --global user.name statsabot
           git config --global user.email ''
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+      - run: uv pip install -e .[dev] --system
+      - run: uv pip freeze
       - name: Regenerate examples and docs
         id: regen
-        run: uv run --python=3.13 --extra=dev scripts/regenerate.py --download-typeshed
+        run: python scripts/regenerate.py --download-typeshed
       - name: Check the generated files with pre-commit
         id: lint
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -10,6 +10,9 @@ on:
       - "**.csv"
       - "**.html"
 
+env:
+  FORCE_COLOR: 1 # Request colored output from CLI tools supporting it
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,6 @@ permissions:
 env:
   FORCE_COLOR: 1 # Request colored output from CLI tools supporting it
   PY_COLORS: 1 # Recognized by the `py` package, dependency of `pytest`
-  # TERM is needed for FORCE_COLOR to work on mypy on Ubuntu,
-  # see https://github.com/python/mypy/issues/13817
-  TERM: xterm-256color
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 concurrency:


### PR DESCRIPTION
And partially revert https://github.com/AlexWaygood/typeshed-stats/pull/287, which broke CI on `main` (https://github.com/AlexWaygood/typeshed-stats/actions/runs/11997335299)