### PR TITLE
improve renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,8 @@
   extends: ["config:recommended"],
   dependencyDashboard: true,
   separateMajorMinor: false,
+  suppressNotifications: ["prEditedNotification"],
+  semanticCommits: "disabled",
   "pre-commit": {
     enabled: true,
   },
@@ -11,13 +13,24 @@
       groupName: "GitHub Actions",
       matchManagers: ["github-actions"],
       description: "Quarterly update of GitHub Action dependencies",
+      schedule: ["every 3 months on the first day of the month"],
     },
     {
       groupName: "most test/lint dependencies",
       matchManagers: ["pep621", "pre-commit"],
+      matchPackageNames: ["!ty"],
       description: "Quarterly update of most test/lint dependencies",
+      schedule: ["every 3 months on the first day of the month"],
+    },
+    {
+      groupName: "ty",
+      matchManagers: ["pep621"],
+      matchPackageNames: ["ty"],
+      description: "Daily ty update",
+      schedule: ["before 4am"],
     },
   ],
-  schedule: ["every 3 months on the first day of the month"],
-  suppressNotifications: ["prEditedNotification"],
+  vulnerabilityAlerts: {
+    commitMessageSuffix: "",
+  },
 }


### PR DESCRIPTION
have renovate check for ty updates every day.

Tested with:

```
% npx --yes --package renovate -- renovate-config-validator
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```

inspired by a similar setup we have in typeshed to have different dependencies updated according to different schedules: <https://github.com/python/typeshed/blob/main/.github/renovate.json5>

and similar to https://github.com/astral-sh/docstring-adder/pull/42