### PR TITLE
Remove deleted rule from ruff ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,9 +122,6 @@ ignore = [
     # Let mypy/pyright complain about blanket type ignores or implicit optional
     "PGH004",
     "RUF013",
-    # Makes code slower and more verbose
-    # https://github.com/astral-sh/ruff/issues/7871
-    "UP038",
 ]
 unfixable = [
     "F841",    # unused variable. ruff keeps the call, but mostly we want to get rid of it all


### PR DESCRIPTION
```console
$ pre-commit run -va ruff-check
ruff check...............................................................Passed
- hook id: ruff-check
- duration: 0.01s

warning: The following rules have been removed and ignoring them has no effect:
    - UP038

All checks passed!
```