### PR TITLE
Use uv/prek in GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
       - run: uv run --python=3.11 --group=dev mypy
 
   pyright:
@@ -50,6 +52,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
       - run: |
           uv python pin 3.11
           uv sync --group=dev
@@ -66,6 +70,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
       - run: uvx prek run -a
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           persist-credentials: true
       - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
       - if: ${{ github.event_name != 'push' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/regen-examples-and-docs.yml
+++ b/.github/workflows/regen-examples-and-docs.yml
@@ -33,18 +33,18 @@ jobs:
         run: |
           git config --global user.name statsabot
           git config --global user.email ''
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
       - uses: astral-sh/setup-uv@v7
-      - run: uv pip install -e . --group=dev --system
+        with:
+          version: "0.11.21"
+          python-version: "3.14"
+      - run: uv sync --group=dev
       - run: uv pip freeze
       - name: Regenerate examples and docs
         id: regen
-        run: python scripts/regenerate.py --download-typeshed
-      - name: Check the generated files with pre-commit
+        run: uv run python scripts/regenerate.py --download-typeshed
+      - name: Check the generated files with prek
         id: lint
-        uses: pre-commit/action@v3.0.1
+        run: uvx prek run -a
       - name: Commit and push the changes
         id: commit
         if: >-
@@ -67,7 +67,7 @@ jobs:
             && steps.lint.outcome == 'success'
             && steps.commit.outcome == 'success'
           }}
-        run: mkdocs gh-deploy -m "🚀 Deploying {sha} with MkDocs {version}" --force
+        run: uv run mkdocs gh-deploy -m "🚀 Deploying {sha} with MkDocs {version}" --force
 
   create-issue-on-failure:
     name: Create an issue if the automated regeneration failed

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -27,18 +27,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
       - uses: astral-sh/setup-uv@v7
-      - run: uv pip install -e . --group=dev --system
+        with:
+          version: "0.11.21"
+          python-version: "3.14"
+      - run: uv sync --group=dev
       - run: uv pip freeze
       - name: Regenerate examples and docs
-        run: python scripts/regenerate.py --download-typeshed
-      - name: Check the generated files with pre-commit
-        uses: pre-commit/action@v3.0.1
+        run: uv run python scripts/regenerate.py --download-typeshed
+      - name: Check the generated files with prek
+        run: uvx prek run -a
       - name: Build docs
-        run: mkdocs build --strict
+        run: uv run mkdocs build --strict
       - name: Upload docs
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.21"
       - name: Run tests under coverage
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- replace the remaining `pre-commit/action` steps with `uvx prek run -a`
- use `setup-uv` instead of `setup-python` and run project commands through `uv run`
- pin uv 0.11.21 in every workflow

## Rationale

This consolidates the workflows on uv and prek, avoids installing dependencies into the runner's system Python, and makes the uv version deterministic across jobs.
