### PR TITLE
Fix abandoned dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,8 +76,8 @@ repos:
       - id: markdownlint-fix
         priority: 3
         args: ["--ignore", "stats_website/.snippets"]
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: 06507ab9500d4a9919b5ebd76d9d5b7074f15c1f # frozen: v3.8.4
     hooks:
       - id: prettier
         priority: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ dev = [
     "pytest-mock==3.15.1",
     "pytest-subtests==0.15.0",
     "mypy==2.1.0",
-    "types-beautifulsoup4==4.12.0.20250516",
     "types-Markdown==3.10.2.20260518",
     "prek==0.4.2",
 ]
@@ -172,7 +171,6 @@ typeCheckingMode = "strict"
 
 # Extra strict settings
 reportMissingModuleSource = "error"
-reportShadowedImports = "error"
 reportCallInDefaultInitializer = "error"
 reportUnnecessaryTypeIgnoreComment = "error"
 


### PR DESCRIPTION
- Switch to a maintained mirror of prettier (the one Ruff uses) that is still updated
- Remove `types-beautifulsoup4 (beautifulsoup4 has been py.typed for a while now)
- Remove a pyright config setting that has been removed without replacement (https://github.com/microsoft/pyright/pull/10891)