### PR TITLE
disable renovate cooldown period for ty-pre-commit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,6 +53,7 @@
       matchPackageNames: ["astral-sh/ty-pre-commit"],
       description: "Daily ty update",
       schedule: ["at any time"],
+      minimumReleaseAge: null,
     },
   ],
   vulnerabilityAlerts: {


### PR DESCRIPTION
we want to dogfood new ty releases as quickly as possible